### PR TITLE
Added user dialog box to select one or more joints from description list

### DIFF
--- a/code/analyzeTemperatureData/get/getDescriptionList.m
+++ b/code/analyzeTemperatureData/get/getDescriptionList.m
@@ -1,0 +1,34 @@
+function desc = getDescriptionList(experimentData)
+% GETJOINTINDEX — Row index of the specified joint in the description list.
+%
+% Syntax:
+%   joint_idx = getJointIndex(joint_name, experimentData)
+%
+% Inputs:
+%   joint_name (string/char) - Joint name to look up (case-insensitive).
+%   experimentData (struct)  - Data struct containing <experiment>.description_list.
+%
+% Output:
+%   joint_idx (double scalar) - Index (row number) of the joint in the description list.
+%                               Returns NaN if not found or input invalid.
+%
+% Example:
+%   idx = getJointIndex('neck_pitch', S);
+%
+% See also: getExperimentName
+
+    arguments
+      experimentData (1,1) struct
+    end
+    
+    experimentName = getExperimentName(experimentData);
+    if ~isfield(experimentData.(experimentName), 'description_list')
+      warning('description_list not found under experiment "%s".', experimentName);
+    end
+    
+    desc = experimentData.(experimentName).description_list;
+    if isstring(desc)
+        desc = cellstr(desc);
+    end
+
+end

--- a/code/analyzeTemperatureData/main.m
+++ b/code/analyzeTemperatureData/main.m
@@ -17,6 +17,7 @@
 % timestamps = (0:0.5:250);                   % seconds (numeric) for demo
 % temperature = 95*sin(2*pi*timestamps/250);   % °C, synthetic
 % temperatureHardwareLimit = 0;                % Example threshold (°C)
+clear, clc
 
 addpath(genpath('.'))
 
@@ -28,21 +29,25 @@ experimentData = load([experimentPath experimentName]);
 
 %% Get data
 
+descriptionList = getDescriptionList(experimentData);
 timestamps = getTimestamps(experimentData);
 
-% The joint names are listed inside the "description list" section of the
-% experiment data (experimentData -> experiment Name -> description_list).
+[joint_idx, isSelected] = listdlg('ListString', descriptionList);
 
-joint_name = 'torso_pitch_mj1_real_aksim2';
-joint_index = getJointIndex(joint_name, experimentData);
-
-temperature = getTemperatureData('torso_pitch_mj1_real_aksim2', experimentData);
-
-%% Process data
-plotTemperatureData(timestamps, temperature, joint_index, joint_name)
-
-diagnostic = errorHandlingTemperature(timestamps, temperature);
-
-printDiagnosticMarkdown(timestamps, diagnostic)
-
-plotOverheatingZones(timestamps, temperature, diagnostic.mask.OVERHEAT, diagnostic.regions.OVERHEAT);
+if isSelected
+    for i = joint_idx
+        
+        current_joint_name = descriptionList{i};
+        
+        temperature = getTemperatureData(current_joint_name, experimentData);
+        plotTemperatureData(timestamps, temperature, joint_idx(i), current_joint_name);
+        
+        diagnostic = errorHandlingTemperature(timestamps, temperature);
+        plotOverheatingZones(timestamps, temperature, diagnostic.mask.OVERHEAT, diagnostic.regions.OVERHEAT);
+    
+        printDiagnosticMarkdown(timestamps, diagnostic);
+        
+    end
+else
+    disp('No joint selected');
+end


### PR DESCRIPTION
As per title

It is not possible to open the dialog box in the monitor where the user's mouse pointer is. The window should be opened by default by the first screen.

Notice that when the dialog pops up in one of the screens you can perform no actions until the dialog is closed.

If you are stuck just check where the dialog box is. You can use the `esc` button to close the dialog wherever it is.

The function could be furtherly wrapped inside a `askJointToAnalyze` and put inside the `utils` folder.

cc @valegagge @andresoll

Closes #46 